### PR TITLE
Fix link to forbidden Rails demo

### DIFF
--- a/2023_08_14.md
+++ b/2023_08_14.md
@@ -18,7 +18,7 @@ Some of the topics we hit on, in the order that we hit them:
 - [No Silver Bullet](http://worrydream.com/refs/Brooks-NoSilverBullet.pdf) by Fred Brooks
 - Sub-podcasting (it's a thing!) [this](https://redplanetlabs.com/)
 - video: [Fred Brooks speaking on No Silver Bullet](https://www.youtube.com/watch?v=HWYrrw7Zf1k)
-- [Ruby on Rails demo](https://www.youtube.com/watch?v=1jHfY0dDZxA) (2005)
+- [Ruby on Rails demo](https://www.youtube.com/watch?v=Gzj723LkRJY) (2005)
 - [Future of coding podcast](https://futureofcoding.org)
 - [Amdahl's law](https://en.wikipedia.org/wiki/Amdahl%27s_law)
 - [FizzBuzzEnterpriseEdition](https://github.com/EnterpriseQualityCoding/FizzBuzzEnterpriseEdition)


### PR DESCRIPTION
Unless there's some really subtle intentional reason that the link actually goes to https://www.youtube.com/watch?v=1jHfY0dDZxA