### PR TITLE
notes for 2024-03-04: links for statemaps

### DIFF
--- a/2024_03_04.md
+++ b/2024_03_04.md
@@ -15,27 +15,17 @@ Charlie Park.
 Some of the topics we hit on, in the order that we hit them:
 
 - [Bryan's rad gnuplot](https://twitter.com/bcantrill/status/1760501008126619967)
-  - [GitHub PR with Bryan's visualizations](https://github.com/oxidecomputer/helios-omicron-brand/pull/12)
 - Tufte
-  - [Pronunciation of "Tufte"](https://www.edwardtufte.com/bboard/q-and-a-fetch-msg?msg_id=00005F) is [/ˈtʌfti/](https://en.wikipedia.org/wiki/Edward_Tufte)
 - [Flame Graphs](https://www.brendangregg.com/flamegraphs.html)
 - [flamegraph-rs](https://github.com/flamegraph-rs/flamegraph)
+- Statemap [generator](https://github.com/TritonDataCenter/statemap) and [explanation](https://www.slideshare.net/bcantrill/visualizing-systems-with-statemaps)
 - OODA
 - [This American Life: A Little Bit of Knowledge](https://www.thisamericanlife.org/293/transcript)
-- [Statemaps](https://github.com/oxidecomputer/statemap)
 - [Minard's diagram](https://www.edwardtufte.com/tufte/minard)
 - https://twitter.com/thingskatedid/status/1386077306381242371
-  - [plot.awk](https://gist.github.com/katef/fb4cb6d47decd8052bd0e8d88c03a102)
-  - Visualizing [regular expressions](https://github.com/katef/libfsm) and [BNF grammars](https://github.com/katef/kgt) with Graphviz
-  - Example implementations of [isvg](https://github.com/dangermike/random_tools/blob/master/isvg) and [idot](https://github.com/dangermike/random_tools/blob/master/idot)
 - [DTrace aggregations](https://bcantrill.dtrace.org/2013/11/10/agghist-aggzoom-and-aggpack/)
 - Rust crate [ratatui](https://github.com/ratatui-org/ratatui)
-- Programs and libraries for plotting and other data visualizations:
-  - [gnuplot](http://www.gnuplot.info/)
-  - [Matplotlib](https://matplotlib.org/)
-  - [ggplot2](https://ggplot2.tidyverse.org/)
-  - [ParaView](https://www.paraview.org/)
-  - [GLVis](https://glvis.org/)
+- [ParaView](https://www.paraview.org/)
 - Simpsons IMDB visualization
 - [Abraham Wald and the airplane diagram with red bullet holes – here’s the origin story](https://www.cameronmoll.com/journal/abraham-wald-red-bullet-holes-origin-story)
 - [Kartlytics](https://www.davepacheco.net/blog/2013/kartlytics/)


### PR DESCRIPTION
Add links to the statemap github repo and Bryan Cantrill's slide deck about what a statemap is.

This was almost ungoogleable because of the frequent use of maps of the United States as a base for visualizations. I finally found it with a quoted text string from the example in the YouTube video.