### PR TITLE
Fix Wired link in 2024_04_08.md

### DIFF
--- a/2024_04_08.md
+++ b/2024_04_08.md
@@ -19,7 +19,7 @@ Our research for this episode:
 - [Kevin Roose](https://www.nytimes.com/by/kevin-roose)
 - [New York Times front page from April 4th, 2024](https://static01.nyt.com/images/2024/04/04/nytfrontpage/scan.pdf)
 - [How I got started as a developer with Andres Freund & Heikki Linnakangas | Path To Citus Con Ep08](https://www.youtube.com/watch?v=V8bw0UepeuI)
-- [The Mystery of ‘Jia Tan,’ the XZ Backdoor Mastermind | WIRED](www.wired.com/story/jia-tan-xz-backdoor/)
+- [The Mystery of ‘Jia Tan,’ the XZ Backdoor Mastermind | WIRED](https://www.wired.com/story/jia-tan-xz-backdoor/)
 - [How one volunteer stopped a backdoor from exposing Linux systems worldwide - The Verge](https://www.theverge.com/2024/4/2/24119342/xz-utils-linux-backdoor-attempt)
 - [Linux backdoor was a long con, possibly with nation-state support, experts say - Nextgov/FCW](https://www.nextgov.com/cybersecurity/2024/04/linux-backdoor-was-long-con-possibly-nation-state-support-experts-say/395511/)
 - [research!rsc: Timeline of the xz open source attack](https://research.swtch.com/xz-timeline)


### PR DESCRIPTION
* Previously Markdown interpreted link as internal GH project URL that lead to a 404 Not Found page, instead of an external URL
* Link to Wired article works now