### PR TITLE
Link to FOSDEM talk via fosdem.org (slides, downloadable).

### DIFF
--- a/2025_02_10.md
+++ b/2025_02_10.md
@@ -21,7 +21,7 @@ Some of the topics we hit on, in the order that we hit them:
 
 - [Ratatui](https://ratatui.rs/)
 - [Orhun's blog](https://orhun.dev/)
-- [Orhun's FOSDEM 2025 talk](https://www.youtube.com/watch?v=iepbyYrF_YQ)
+- Orhun's FOSDEM 2025 talk [(YT)](https://www.youtube.com/watch?v=iepbyYrF_YQ) or [(fosdem.org) with slides link etc.](https://fosdem.org/2025/schedule/event/fosdem-2025-5496-bringing-terminal-aesthetics-to-the-web-with-rust-and-vice-versa-/)
 - [Minitel](https://en.wikipedia.org/wiki/Minitel)
 - [Minitel rust stack](https://github.com/plule/minitel)
 - [ratatui on Minitel](https://www.youtube.com/watch?v=1qwrJ4NbFls)


### PR DESCRIPTION
Link to talk via fosdem.org as well as youtube.  Fosdem.org includes link to slides, and is ad-free and downloadable (for those that don't have YT Premium).  Also links other talks on that track.