### PR TITLE
2025_03_03: link Rain's lifetime variance tutorial

### DIFF
--- a/2025_03_03.md
+++ b/2025_03_03.md
@@ -31,6 +31,7 @@ Some of the topics we hit on, in the order that we hit them:
 - [daft crate](https://crates.io/crates/daft)
 - [diffus crate](https://crates.io/crates/diffus)
 - [syn crate](https://crates.io/crates/syn)
+- Rain's [how lifetime variance works](https://lifetime-variance.sunshowers.io) tutorial
 
 If we got something wrong or missed something, please file a PR!
 Our next show will likely be on Monday at 5p Pacific Time on our Discord


### PR DESCRIPTION
Adds a tutorial mentioned in "A crate is born": Rain's [https://lifetime-variance.sunshowers.io](https://lifetime-variance.sunshowers.io).

#### Why
I reached for these show notes first to find it, presumably others would as well. As a (fellow) rustacean who's still getting a grip of lifetime variance in Rust, hearing that an Oxide human made a tutorial about it instantly caught my attention. 

#### Decision
This links to the start of the tutorial even though the conversation in the episode brought it up regarding covariance (primarily).

~ TG-Tecie