### PR TITLE
2025-03-17: Add more links

### DIFF
--- a/2025_03_17.md
+++ b/2025_03_17.md
@@ -26,8 +26,19 @@ Some of the topics we hit on, in the order that we hit them:
 - [The Oxide John von Neumann bust](https://x.com/oxidecomputer/status/1368393911727575041)
 - [Intel's new CEO plots overhaul of manufacturing and AI operations](https://www.reuters.com/technology/intels-new-ceo-plots-overhaul-manufacturing-ai-operations-2025-03-17/)
 - [Lip-Bu Tan: Remaking Our Company for the Future](https://newsroom.intel.com/corporate/lip-bu-tan-remaking-our-company-future)
-- [Intel oneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/overview.html)
 - [Morris Chang: "A very discourteous fellow"](https://www.youtube.com/watch?v=X8UWxXJHHbE)
+- [Oxide and Friends Predictions 2025](https://youtu.be/-pk6VokHpGY)
+- Bryan's Intel reading list
+  - [The Pentium Chronicles](https://ieeexplore.ieee.org/book/5989703) by
+    [Bob Colwell](https://en.wikipedia.org/wiki/Bob_Colwell), author of
+    [Performance Effects of Architectural Complexity in the Intel 432](https://archive.org/details/432_complexity_paper)
+  - [Slingshot](https://www.hectorruiz.com/book) by [Hector Ruiz](https://en.wikipedia.org/wiki/Hector_Ruiz)
+- [IBM Global Business Services](https://en.wikipedia.org/wiki/IBM_Consulting)
+- [Who Says Elephants Can't Dance?](https://www.harpercollins.com/products/who-says-elephants-cant-dance-louis-v-gerstner) by
+  [Lou Gerstner](https://en.wikipedia.org/wiki/Lou_Gerstner)
+- [Intel oneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/overview.html)
+- [Altera](https://en.wikipedia.org/wiki/Altera)
+- [Intel Pathfinder](https://www.theregister.com/2023/01/30/intel_ris_v_pathfinder_discontinued/)
 
 If we got something wrong or missed something, please file a PR!
 Our next show will likely be on Monday at 5p Pacific Time on our Discord


### PR DESCRIPTION
Move oneAPI link down; I think it was discusssed later, but am not sure.