### PR TITLE
Inflict Oxford comma

### DIFF
--- a/2025_04_28.md
+++ b/2025_04_28.md
@@ -12,7 +12,7 @@ In addition to
 [Bryan Cantrill](https://bsky.app/profile/bcantrill.bsky.social) and
 [Adam Leventhal](https://bsky.app/profile/ahl.bsky.social),
 we were joined by
-[Rachel Stephens](https://bsky.app/profile/rstephens.me)
+[Rachel Stephens](https://bsky.app/profile/rstephens.me),
 [Adam Jacob](https://bsky.app/profile/adamhjk.me),
 and [Eliza Weisman](https://bsky.app/profile/elizas.website).
 


### PR DESCRIPTION
Makes it clear the hosts were joined by Rachel Stephens and Adam Jacob, not by Rachel Stephens Adam Jacob.