### PR TITLE
2025-06-09: Add links

### DIFF
--- a/2025_06_09.md
+++ b/2025_06_09.md
@@ -24,12 +24,17 @@ Previous episodes mentioned:
 - [OxF: A Crate is Born](https://oxide-and-friends.transistor.fm/episodes/a-crate-is-born)
 - [OxF: The Network Behind the Network](https://oxide-and-friends.transistor.fm/episodes/the-network-behind-the-network)
 - [OxF: Bringing up Cosmo](https://oxide-and-friends.transistor.fm/episodes/bringing-up-cosmo)
+- [OxF: Holistic Engineering with Robert Mustacchi](https://oxide-and-friends.transistor.fm/episodes/holistic-engineering-with-robert-mustacchi)
 - [OxF: RIP USENIX ATC](https://oxide-and-friends.transistor.fm/episodes/rip-usenix-atc)
 - [OxF: Dijkstra’s Tweetstorm](https://oxide-and-friends.transistor.fm/episodes/dijkstras-tweetstorm-2021-10-18)
 
 Some of the topics we hit on, in the order that we hit them:
 
+- [mdb (Solaris debugger)](https://en.wikipedia.org/wiki/Modular_Debugger)
+- [kang](https://github.com/TritonDataCenter/kang)
 - [omdb ground rules](https://github.com/oxidecomputer/omicron/blob/0d746e055a3d0ee7fc2dc199d770cb71e1cb1001/dev-tools/omdb/src/bin/omdb/main.rs#L7)
+- [`flipone`](https://github.com/illumos/illumos-gate/blob/09a032ce55a4b25e9a50eba798b5dfa1f449cb4b/usr/src/cmd/mdb/common/modules/genunix/genunix.c#L3491)
+  * documented as ["the vik_rev_level 2 special"](https://github.com/illumos/illumos-gate/blob/09a032ce55a4b25e9a50eba798b5dfa1f449cb4b/usr/src/cmd/mdb/common/modules/genunix/genunix.c#L4171)
 
 If we got something wrong or missed something, please file a PR!
 Our next show will likely be on Monday at 5p Pacific Time on our Discord


### PR DESCRIPTION
I couldn't find the dtrace %j jazzy format.

https://github.com/illumos/illumos-gate/blob/a386cc11a86ecb60f5a48078d22c1500e2ad003e/usr/src/lib/libdtrace/common/dt_printf.c#L647

Perhaps I misunderstood what this was.